### PR TITLE
Fix index error and recursive counting issue in remove_trend_nonstationarity method

### DIFF
--- a/src/stationarity_toolkit/stationarity_toolkit.py
+++ b/src/stationarity_toolkit/stationarity_toolkit.py
@@ -314,7 +314,7 @@ class StationarityToolkit:
 
         if self._recurse_cnt == 0:
             self.timeseries = ts if ts is not None else self.timeseries
-            self._trend_initial_value = self.timeseries.iloc[0, 0].copy()
+            self._trend_initial_value = self.timeseries.iloc[0].copy()
             self._index = self._get_index()
 
         if self._recurse_cnt == 0:
@@ -340,16 +340,16 @@ class StationarityToolkit:
                 "Both tests conclude that the series is not stationary -> Removing trend**"
             )
             self._differencing = "trend"
-            self._trend_initial_value = ts.iloc[0, 0].copy()
+            self._trend_initial_value = ts.iloc[0].copy()
             ts_dif = ts - ts.shift(1)
             if self.remove_trend_nonstationarity(ts_dif) is None:
                 self.logger.info("Trend Removal didn't work. Removing Seasonality")
                 self._differencing = "seasonality"
-                self._seasonality_initial_value = ts.iloc[0:52, 0].copy()
+                self._seasonality_initial_value = ts.iloc[0:52].copy()
                 ts_seasonal_diff = ts - ts.shift(52)
                 if self.remove_trend_nonstationarity(ts_seasonal_diff) is None:
                     self._differencing = "seasonal_trend"
-                    self._trend_initial_value = ts_seasonal_diff.iloc[52, 0]
+                    self._trend_initial_value = ts_seasonal_diff.iloc[52]
                     self.logger.info(
                         "Seasonality Removal didn't work. Removing Trend on top of Seasonal Differencing"
                     )

--- a/src/stationarity_toolkit/stationarity_toolkit.py
+++ b/src/stationarity_toolkit/stationarity_toolkit.py
@@ -325,8 +325,13 @@ class StationarityToolkit:
             self.logger.info("REMOVE TREND NON-STATIONARITY")
             self.logger.info("-----------------------LOG-------------------------")
             self.logger.info("INITIAL STATISTICAL TESTS")
-        dfoutput = self.adf_test(ts.dropna())
-        kpss_output = self.kpss_test(ts.dropna())
+        # Perform ADF and KPSS tests
+        try:
+            dfoutput = self.adf_test(ts.dropna())
+            kpss_output = self.kpss_test(ts.dropna())
+        except ValueError as e:
+            self.logger.error(f"Error occurred during ADF or KPSS test: {e}")
+            return None
         self._recurse_cnt += 1
         self.logger.info("----------------------------------------------------")
         self.logger.info(f"Recurse Count: {self._recurse_cnt}")
@@ -349,7 +354,11 @@ class StationarityToolkit:
                 ts_seasonal_diff = ts - ts.shift(52)
                 if self.remove_trend_nonstationarity(ts_seasonal_diff) is None:
                     self._differencing = "seasonal_trend"
-                    self._trend_initial_value = ts_seasonal_diff.iloc[52]
+                    if len(ts_seasonal_diff) > 52:
+                        self._trend_initial_value = ts_seasonal_diff.iloc[52]
+                    else:
+                        self.logger.error("ts_seasonal_diff doesn't have enough elements.")
+                        return None
                     self.logger.info(
                         "Seasonality Removal didn't work. Removing Trend on top of Seasonal Differencing"
                     )
@@ -357,11 +366,16 @@ class StationarityToolkit:
                         1
                     )
                     ts_seasonal_trend_diff.index = self._index
-                    return self.remove_trend_nonstationarity(ts_seasonal_trend_diff)
+                    result = self.remove_trend_nonstationarity(ts_seasonal_trend_diff)
+                    self._recurse_cnt = 0
+                    return result
                 else:
                     self.remove_trend_nonstationarity(ts_seasonal_diff)
+                    self._recurse_cnt = 0
             else:
-                return self.remove_trend_nonstationarity(ts_dif)
+                result = self.remove_trend_nonstationarity(ts_dif)
+                self._recurse_cnt = 0
+                return result
             ts_dif.index = self._index
         elif (
             (dfoutput["p-value"] >= self.alpha)


### PR DESCRIPTION
Fix 1: Corrected the indexing to properly handle one-dimensional data.

Fix2: Fixed a bug in recursive counting in `remove_trend_nonstationarity` method. The fix ensures `self._recurse_cnt is reset to 0` after handling each recursive call, ensuring correct iteration counts and proper removal of trend-based non-stationarity.

Testing Code:

```
import pandas as pd
from stationarityToolkit.src.stationarity_toolkit.stationarity_toolkit import StationarityToolkit

# Replace `your_time_series_data` with your actual time series data
toolkit = StationarityToolkit(0.0005)

# Define the data
data = [1, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76]

# Define the date range
date_range = pd.date_range(start='2023-09-16', periods=len(data), freq='D')

# Create the Series object with date_range as index
series = pd.Series(data, index=date_range)

toolkit.remove_trend_nonstationarity(series)
```

